### PR TITLE
Revert Kent toolchain hack from 2012

### DIFF
--- a/modules/course/examples/bar.occ
+++ b/modules/course/examples/bar.occ
@@ -20,55 +20,7 @@
 --
 
 #INCLUDE "course.module"
---#INCLUDE "time.module"
-
---{{{  FUNCTION seconds
---* Convert seconds to timer ticks.
--- @param s Time in seconds
--- @return Time in timer ticks
-INT INLINE FUNCTION seconds (VAL INT s)
-  INT ticks:
-  VALOF
-    #IF TARGET.BITS.PER.WORD = 16
-    ticks := s * 1000
-    #ELSE
-    ticks := s * 1000000
-    #ENDIF
-    RESULT ticks
-:
---}}}
-
---{{{  FUNCTION milliseconds
---* Convert milliseconds to timer ticks.
--- @param ms Time in milliseconds
--- @return Time in timer ticks
-INT INLINE FUNCTION milliseconds (VAL INT ms)
-  INT ticks:
-  VALOF
-    #IF TARGET.BITS.PER.WORD = 16
-    ticks := ms
-    #ELSE
-    ticks := ms * 1000
-    #ENDIF
-    RESULT ticks
-:
---}}}
-
---{{{  FUNCTION microseconds
---* Convert microseconds to timer ticks.
--- @param us Time in microseconds
--- @return Time in timer ticks
-INT INLINE FUNCTION microseconds (VAL INT us)
-  INT ticks:
-  VALOF
-    #IF TARGET.BITS.PER.WORD = 16
-    ticks := us / 1000
-    #ELSE
-    ticks := us
-    #ENDIF
-    RESULT ticks
-:
---}}}
+#INCLUDE "time.module"
 
 --{{{  O.REQ protocol
 PROTOCOL O.REQ


### PR DESCRIPTION
This was a temporary workaround for a Kent toolchain problem in 2012 --
I'm assuming it's been fixed since! (I spotted this because I wanted to
show my students at Abertay some occam code...)

This reverts commit e62bcddfb8d6cfd6498e3ea6dfc58fd1e10533e9.