### PR TITLE
Build 20200327

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,38 @@
 *.so
 *~
 
-
 # Dangerous, but we'll do it.
 config.h
 config.log
 defaults.scm
+
+# Build outputs/generated as part of build
+# 20200327 MCJ
+**tbc
+**compile*
+modules/random/examples/test-driver
+modules/useful/examples/test-driver
+runtime/libtvm/dispatch-cookie
+runtime/libtvm/dispatch_ins.c
+runtime/libtvm/ins_names.h
+runtime/libtvm/instructions.inc
+runtime/libtvm/jumptbl_ex_sec.c
+runtime/libtvm/jumptbl_pri.c
+runtime/libtvm/jumptbl_sec.c
+runtime/libtvm/stamp-h2
+runtime/libtvm/tvm_config.h
+tests/cgtests/test-driver
+tests/hereticc/test-driver
+tests/occbench/test-driver
+tools/plinker/build.pl
+tools/plinker/plinker.pl
+tools/plinker/store.pl
+tools/plinker/tce-dump.pl
+tools/tenctool/tencdump
+tools/tenctool/tencid
+tools/tenctool/tencstrip
+tvm/posix/tvm
+tvm/posix/tvm-posix
 
 # Built targets
 tools/mkoccdeps/mkoccdeps

--- a/configure.ac
+++ b/configure.ac
@@ -16,28 +16,27 @@ if test "x$OCCBUILD_API_VERSION" != x3; then
 fi
 
 OCCAM_CONFIG_SUBDIRS(tools/ilibr)
-OCCAM_CONFIG_SUBDIRS(tools/kroc)
+# OCCAM_CONFIG_SUBDIRS(tools/kroc)
 OCCAM_CONFIG_SUBDIRS(tools/mkoccdeps)
 if test $OCCBUILD_TOOLCHAIN != tock; then
   OCCAM_CONFIG_SUBDIRS(tools/occ21)
 fi
 OCCAM_CONFIG_SUBDIRS(tools/occamdoc)
 
-if test $OCCBUILD_TOOLCHAIN = kroc -o $OCCBUILD_TOOLCHAIN = tock; then
-  OCCAM_CONFIG_TARGET_SUBDIRS(runtime/ccsp)
-fi
+#if test $OCCBUILD_TOOLCHAIN = kroc -o $OCCBUILD_TOOLCHAIN = tock; then
+#  OCCAM_CONFIG_TARGET_SUBDIRS(runtime/ccsp)
+#fi
 
-if test $OCCBUILD_TOOLCHAIN = kroc; then
-  OCCAM_CONFIG_SUBDIRS(tools/tranx86)
-
-  OCCAM_CONFIG_TARGET_SUBDIRS(runtime/libkrocif)
-fi
+#if test $OCCBUILD_TOOLCHAIN = kroc; then
+#  OCCAM_CONFIG_SUBDIRS(tools/tranx86)
+#  OCCAM_CONFIG_TARGET_SUBDIRS(runtime/libkrocif)
+#fi
 
 if test $OCCBUILD_TOOLCHAIN = tvm; then
   OCCAM_CONFIG_SUBDIRS(tools/plinker)
   OCCAM_CONFIG_SUBDIRS(tools/tenctool)
-  OCCAM_CONFIG_SUBDIRS(tools/skroc)
-  OCCAM_CONFIG_SUBDIRS(tools/slinker)
+  # OCCAM_CONFIG_SUBDIRS(tools/skroc)
+  # OCCAM_CONFIG_SUBDIRS(tools/slinker)
   OCCAM_CONFIG_SUBDIRS(tools/tinyswig)
 
   OCCAM_CONFIG_TARGET_SUBDIRS(runtime/libtvm)
@@ -54,72 +53,77 @@ fi
 # The modules must be built in dependency order.
 OCCAM_CONFIG_TARGET_SUBDIRS(modules/inmoslibs/libsrc)
 #OCCAM_CONFIG_TARGET_SUBDIRS(modules/nocclibs/libsrc)
-OCCAM_CONFIG_TARGET_SUBDIRS(modules/bsclib/libsrc)
-OCCAM_CONFIG_TARGET_SUBDIRS(modules/cif/libsrc)
+#OCCAM_CONFIG_TARGET_SUBDIRS(modules/bsclib/libsrc)
+#OCCAM_CONFIG_TARGET_SUBDIRS(modules/cif/libsrc)
+OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/libsrc)
 
-if test "x$KROC_RMOX" = "x"; then
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/dynproc/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/pony/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/udc/libsrc)
-fi
 OCCAM_CONFIG_TARGET_SUBDIRS(modules/random/libsrc)
 OCCAM_CONFIG_TARGET_SUBDIRS(modules/time/libsrc)
-OCCAM_CONFIG_TARGET_SUBDIRS(modules/raster/libsrc)
-if test "x$KROC_RMOX" = "x"; then
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/useful/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/fmtoutlib/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/cdx/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/trap/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/ttyutil/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/moa/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/occSDL/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/sdlraster/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/occade/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/occGL/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/ocuda/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/button/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/video/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/graphics3d/libsrc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/player/libsrc)
+OCCAM_CONFIG_TARGET_SUBDIRS(tests/cgtests)
 
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/bsclib/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/button/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/cdx/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/cif/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/answers)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/exercises)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/dynproc/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/graphics3d/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/moa/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/occGL/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/occSDL/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/occade/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/ocuda/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/player/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/player/exercises)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/pony/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/random/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/raster/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/sdlraster/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/trap/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/ttyutil/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/udc/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/useful/examples)
-  OCCAM_CONFIG_TARGET_SUBDIRS(modules/video/examples)
-
-  OCCAM_CONFIG_TARGET_SUBDIRS(demos/bar)
-  OCCAM_CONFIG_TARGET_SUBDIRS(demos/game)
-  OCCAM_CONFIG_TARGET_SUBDIRS(demos/robots)
-  OCCAM_CONFIG_TARGET_SUBDIRS(demos/shootout)
-  OCCAM_CONFIG_TARGET_SUBDIRS(demos/ttygames)
-
-  OCCAM_CONFIG_TARGET_SUBDIRS(tests/cgtests)
-  OCCAM_CONFIG_TARGET_SUBDIRS(tests/hereticc)
-  OCCAM_CONFIG_TARGET_SUBDIRS(tests/occbench)
-fi
-
+# if test "x$KROC_RMOX" = "x"; then
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/dynproc/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/pony/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/udc/libsrc)
+# fi
+# OCCAM_CONFIG_TARGET_SUBDIRS(modules/random/libsrc)
+# OCCAM_CONFIG_TARGET_SUBDIRS(modules/time/libsrc)
+# OCCAM_CONFIG_TARGET_SUBDIRS(modules/raster/libsrc)
+# if test "x$KROC_RMOX" = "x"; then
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/useful/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/fmtoutlib/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/cdx/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/trap/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/ttyutil/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/moa/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/occSDL/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/sdlraster/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/occade/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/occGL/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/ocuda/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/button/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/video/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/graphics3d/libsrc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/player/libsrc)
+# 
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/bsclib/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/button/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/cdx/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/cif/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/answers)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/course/exercises)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/dynproc/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/graphics3d/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/moa/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/occGL/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/occSDL/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/occade/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/ocuda/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/player/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/player/exercises)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/pony/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/random/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/raster/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/sdlraster/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/trap/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/ttyutil/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/udc/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/useful/examples)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(modules/video/examples)
+# 
+#   OCCAM_CONFIG_TARGET_SUBDIRS(demos/bar)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(demos/game)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(demos/robots)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(demos/shootout)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(demos/ttygames)
+# 
+#   OCCAM_CONFIG_TARGET_SUBDIRS(tests/cgtests)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(tests/hereticc)
+#   OCCAM_CONFIG_TARGET_SUBDIRS(tests/occbench)
+# fi
+ 
 OCCAM_CONFIG_SUBDIRS(doc)
 
 AC_CONFIG_FILES([Makefile])

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ if test "x$OCCBUILD_API_VERSION" != x3; then
 fi
 
 OCCAM_CONFIG_SUBDIRS(tools/ilibr)
-# OCCAM_CONFIG_SUBDIRS(tools/kroc)
+OCCAM_CONFIG_SUBDIRS(tools/kroc)
 OCCAM_CONFIG_SUBDIRS(tools/mkoccdeps)
 if test $OCCBUILD_TOOLCHAIN != tock; then
   OCCAM_CONFIG_SUBDIRS(tools/occ21)

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ if test $OCCBUILD_TOOLCHAIN = tvm; then
   OCCAM_CONFIG_SUBDIRS(tools/tenctool)
   # OCCAM_CONFIG_SUBDIRS(tools/skroc)
   # OCCAM_CONFIG_SUBDIRS(tools/slinker)
-  OCCAM_CONFIG_SUBDIRS(tools/tinyswig)
+  # OCCAM_CONFIG_SUBDIRS(tools/tinyswig)
 
   OCCAM_CONFIG_TARGET_SUBDIRS(runtime/libtvm)
 
@@ -124,7 +124,7 @@ OCCAM_CONFIG_TARGET_SUBDIRS(tests/cgtests)
 #   OCCAM_CONFIG_TARGET_SUBDIRS(tests/occbench)
 # fi
  
-OCCAM_CONFIG_SUBDIRS(doc)
+# OCCAM_CONFIG_SUBDIRS(doc)
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/tools/kroc/occbuild.in
+++ b/tools/kroc/occbuild.in
@@ -155,7 +155,9 @@ def make_relative_path(source, dest):
 	if output == []:
 		return "."
 	else:
-		return apply(os.path.join, output)
+		# 20200327 MCJ
+		# Was apply(...), which went away in Python3
+		return os.path.join(*output)
 
 def run(cmd):
 	"""Run a command, and check that it succeeded."""
@@ -370,7 +372,7 @@ def get_install_dir(default, default_suffix):
 def get_uselibs(etc_file):
 	"""Extract all the USELIB comments from a .etc file."""
 	comments = capture(programs["tce-dump.pl"] + ["-C", etc_file])
-	uselibs = re.findall(r"\.USELIB\s+(.*?)\s*\n", comments)
+	uselibs = re.findall(r"\.USELIB\s+(.*?)\s*\n", comments.decode("utf-8"))
 	return uselibs
 
 def resolve_library(lib):
@@ -393,7 +395,7 @@ def resolve_libraries(libs):
 		path = resolve_library(lib)
 		if path is None:
 			die("Unable to resolve library: ", lib)
-		if not paths.has_key(path):
+		if path not in paths:
 			result.append(path)
 			paths[path] = True
 	return result

--- a/tools/occamdoc/occamdoc.in
+++ b/tools/occamdoc/occamdoc.in
@@ -19,7 +19,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
-import re, sys, xml.dom.minidom, codecs, StringIO, getopt, os
+import re, sys, xml.dom.minidom, codecs, getopt, os
+try:
+	from StringIO import StringIO
+except:
+	from io import StringIO
 
 VERSION = "$Revision$"[11:-2]
 CONTACT = "kroc-bugs@kent.ac.uk"
@@ -477,7 +481,7 @@ def parse_comment(lines):
 				level -= 1
 		parts[-1] += l + "\n"
 
-	parts = map(lambda s: s.strip(), parts)
+	parts = list(map(lambda s: s.strip(), parts))
 
 	if parts[0] == "":
 		parts[0] = None
@@ -855,7 +859,7 @@ def decl_to_xml(doc, decl, errors):
 	el.setAttribute("type", decl.type)
 	try:
 		decl_to_xml_body(doc, decl, el, errors)
-	except OccamDocException, e:
+	except OccamDocException as e:
 		errors.append("Error: In comment starting at " + decl.error_pos + ": " + str(e))
 		errors.append("  Skipping rest of " + decl.ident)
 	return el
@@ -1018,7 +1022,7 @@ def copy_file(filename, output_dir):
 	fo.close()
 
 def usage():
-	print """occamdoc, version """ + VERSION + """
+	print ("""occamdoc, version """ + VERSION + """
 Usage: occamdoc [OPTION]... FILE [FILE]...
 
 Read occam-pi source files and extract documentation.
@@ -1034,7 +1038,7 @@ Read occam-pi source files and extract documentation.
 -v                           Be verbose: say what's being done
 --help                       Display this help and exit
 
-Report bugs to <""" + CONTACT + """>."""
+Report bugs to <""" + CONTACT + """>.""")
 
 def main(args):
 	try:
@@ -1110,7 +1114,7 @@ def main(args):
 				else:
 					decls[ident] = decl
 			status("%d definitions\n" % len(decl.children))
-		except OccamDocException, e:
+		except OccamDocException as e:
 			status("failed\n")
 			print >>sys.stderr, "Error: At " + f.pos_str() + ": " + str(e)
 			print >>sys.stderr, "  Skipping rest of " + file
@@ -1141,11 +1145,11 @@ def main(args):
 		if output_dir is not None:
 			f.close()
 		status("done\n")
-	except OccamDocException, e:
+	except OccamDocException as e:
 		status("failed\n")
 		print >>sys.stderr, "Error: During output: " + str(e)
 		return 1
-	except IOError, e:
+	except IOError as e:
 		status("failed\n")
 		print >>sys.stderr, "Error writing XML file: " + str(e)
 		return 1
@@ -1175,11 +1179,11 @@ def main(args):
 			copy_file("occamdoc.css", output_dir)
 
 			status("done\n")
-	except OccamDocException, e:
+	except OccamDocException as e:
 		status("failed\n")
 		print >>sys.stderr, "Error: During conversion: " + str(e)
 		return 1
-	except IOError, e:
+	except IOError as e:
 		status("failed\n")
 		print >>sys.stderr, "Error: While writing output files: " + str(e)
 		return 1


### PR DESCRIPTION
This commit disables most of the build.

Because the build has sat for a long time, and operating systems and compilers have moved on, there's a lot of ... staleness... in the codebase.

The changes are primarily to configure.ac, and it involves commenting out everything that doesn't *need* to exist for a working occ21/tvm build. (I have no idea how `kroc` will play on modern, 64-bit processors or operating systems.)

Once code is generating and running again, we'll look at bringing `kroc` back in as a runtime, and then can revisit the various foreign libraries (OpenGL, etc.). For now, though, I'd like to see the portable interpreter run bytecode.
 